### PR TITLE
Support fenced code blocks, inline code, sentence spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ Change Log
 (*[semantic versioning](https://semver.org/) [ambitioned](http://www.dictionary.com/browse/ambitioned)
 for releases but not guaranteed...)*
 
+1.5.0
+-----
+
+- Add `reflowMarkdown.doubleSpaceBetweenSentences` setting to insert two
+  spaces instead of one between sentences.
+- Don't split inline code spans onto separate lines.
+- Support fenced code blocks surrounded by three back-ticks (` ``` `)
+- Don't change the indentation level when reflowing blockquotes.
+- Within numbered and bulleted lists, keep the indentation before and the
+  number of spaces after a list marker unchanged.
+
 1.4.4
 -----
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ by [Troels Damgaard](https://github.com/dontrolle/vscode-reflow-lines).  Instead
 
 Format the current heading, paragraph, list, or blockquote to have lines no longer than your preferred line length, using the `alt+q` shortcut or your own user-specific keyboard-binding.
 
-This extension defaults to reflowing lines to be no more than 80 characters long. The preferred line length may be overriden using the config value of `reflowMarkdown.preferredLineLength`.
+This extension defaults to reflowing lines to be no more than 80 characters long. The preferred line length may be overridden using the config value of `reflowMarkdown.preferredLineLength`.
 
 By default, it preserves indent for paragraph, when reflowing. This behavior may be switched off, by setting the configuration option `reflowMarkdown.preserveIndent` to `false`.
 
@@ -16,8 +16,9 @@ Extension Settings
 
 This extension contributes the following settings:
 
-* `reflow.preferredLineLength`: Set the preferred line length for reflowing paragraph (default: `80`).
-* `reflow.preserveIndent`: Preserve paragraph indent when reflowing paragraph (default `true`).
+* `reflowMarkdown.preferredLineLength`: Set the preferred line length for reflowing paragraph (default: `80`).
+* `reflowMarkdown.preserveIndent`: Preserve paragraph indent when reflowing paragraph (default `true`).
+* `reflowMarkdown.doubleSpaceBetweenSentences`: Insert two spaces instead of one between each sentence (default `false`).
 
 Keyboard Shortcuts
 ------------------

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "reflow-markdown",
   "displayName": "Reflow Markdown",
   "description": "Format lines in markdown headers, paragraphs, blockquotes, lists, etc. to a preferred line-length.",
-  "version": "1.4.4",
+  "version": "1.5.0",
   "publisher": "marvhen",
   "icon": "img/logo.png",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,11 @@
           "type": "boolean",
           "default": true,
           "description": "Preserve paragraph indent when reflowing lines."
+        },
+        "reflowMarkdown.doubleSpaceBetweenSentences": {
+          "type": "boolean",
+          "default": false,
+          "description": "Insert two spaces instead of one between each sentence."
         }
       }
     },

--- a/src/testable.ts
+++ b/src/testable.ts
@@ -13,19 +13,27 @@ export interface StartEndInfo {
     indents: Indents;
 }
 
-// replaces spaces within link text (in square brackets) with another charcter
+// replaces spaces within link text (in square brackets) with another character
 // that is highly unlikely to be present.  The \x08 (backspace) character is a
 // good candidate...
 export function replaceSpacesInLinkTextWithBs(txt: string): string {
     return txt.replace(/\[.*?\]/g, (substr, ...args) => {
         return substr.replace(/\s/g, "\x08"); // x08 is hex ascii code for the 'backspace' character
     });
-    
+   
 }
 
-// true if text is zero or more spaces + [ (1 or more digits + 1 decimal) OR (1 dash or asterick) ] + 1 or more spaces   
+// replaces spaces within inline code (surrounded by either one or two
+// back-ticks) with the \0x08 (backspace) character
+export function replaceSpacesInInlineCodeWithBs(txt: string): string {
+    return txt.replace(/`(`([^`]|`[^`])*`|.*?)`/g, (substr, ...args) => {
+        return substr.replace(/\s/g, "\x08"); // x08 is hex ascii code for the 'backspace' character
+    });  
+}
+
+// true if text is zero or more spaces + [ (1 or more digits + 1 decimal) OR (1 dash or asterisk) ] + 1 or more spaces   
 export function isListStart(text: string): RegExpMatchArray {
-    return text.match(/^\s*((\d+\.)|([-\*]))\s+/);        
+    return text.match(/^\s*((\d+\.)|([-\*]))(\s+)/);        
 }
 
 // line beginning + [zero or more spaces + 1 greater than sign](one-or-more)    
@@ -52,6 +60,10 @@ export function markdownBlockQuoteLevelFromString(text: string): number {
     return markdownBlockQuoteLevelFromRegExMatch(isBlockQuote(text));    
 }
 
+export function isFencedCodeBlockDelimiter(text: string): RegExpMatchArray {
+    return text.match(/^(\s*```)/);
+}
+
 export function getLineIndent(firstNonWhitespaceCharacterIndex: number, text: string): Indents {
     
     let startLnSpaces = " ".repeat(firstNonWhitespaceCharacterIndex);
@@ -68,7 +80,7 @@ export function getLineIndent(firstNonWhitespaceCharacterIndex: number, text: st
     regExMatches = isBlockQuote(text)
     if (regExMatches) {
         var level =  markdownBlockQuoteLevelFromRegExMatch(regExMatches);
-        var indent = "  " + ">".repeat(level) + " ";
+        var indent = startLnSpaces + "> ".repeat(level);
         return {
             firstLine: indent,
             otherLines: indent,

--- a/test/mdtest.md
+++ b/test/mdtest.md
@@ -6,14 +6,22 @@ paragraph start line, line 7 should be a paragraph end line, and lines 5 and 6
 should be neither because
 they are is in the middle.
 
+Sentences can end with either a period, a question mark, or an exclamation mark! Punctuation marks that appear within a "quotation should also end a sentence."
+If `reflowMarkdown.doubleSpaceBetweenSentences` is `true` then there should be two spaces between each sentence after reflow is applied.
+
 BlockQuotes
 -----------
 
-  > This is a markdown blockquote that begins on line 11 and ends on line 13. When reflow is applied to
+  > This is a markdown blockquote that begins on line 12 and ends on line 14. When reflow is applied to
   > blockquotes, the blockquote syntax is  first removed and then restored after reflowing.  The indentation
   > that is used on the first line of the blockquote is used for the other lines in the blockquote.
   > > This is a blockquote nested
   > > inside of another blockquote.
+
+> This is a markdown blockquote that begins on line 18 and ends on line 19. The indentation level of the first line should not be changed when reflow is applied to
+> blockquotes,  The indentation that is used on the first line of the blockquote is used for the other lines in the blockquote.
+> > This is a blockquote nested
+> > inside of another blockquote.
 
 Number Lists
 ------------
@@ -29,21 +37,50 @@ Number Lists
 
 4. This is the fourth list item.
 
-5. This is yet antother item.
+5. This is yet another item.
 
-6. This is yet antother item.
+6. This is yet another item.
 
-7. This is yet antother item.
+7. This is yet another item.
 
-8. This is yet antother item.
+8. This is yet another item.
 
-9. This is yet antother item.
+9. This is yet another item.
 
-10. This is yet antother item.
+10. This is yet another item.
 
-11. This is yet antother item.
+11. This is yet another item.
 
 12. TODO: Make the numbers auto-renumber
+
+List Formats
+------------
+
+The indentation and spaces around the list marker in the first line should
+remain unchanged, and the following lines should continue the indentation of
+the text following the list marker.
+
+1.  Numbered list with double spaces after list marker.  This format can be used to make sure the text following the list marker is always aligned even if the list contains 10 or more items.
+2.  This is the second list item and it is very long. When reflow is applied,
+    the lines that follow the first line will all be indented such that they
+    start at the same place that the text starts fort on the first line, rather
+    than starting right under the number.
+3.  This is the third list item.
+4.  This is the fourth list item.
+5.  This is yet another item.
+6.  This is yet another item.
+7.  This is yet another item.
+8.  This is yet another item.
+9.  This is yet another item.
+10. This is yet another item.
+11. This is yet another item.
+12. This is yet another item.
+
+Bulleted lists can also be indented to provide a consistent level of indentation for continued lines.
+
+  - Bulleted list with double spaces before the list marker.  Using this format aligns the text to the same indentation label as the numbered list in the previous example.
+  - This is the second list item.
+  - This is the third list item.
 
 Hyperlinks (where the text does not have white space in it)
 -----------------------------------------------------------
@@ -70,3 +107,30 @@ Here is a similar paragraph to the one above but there are [multiple hyperlinks 
 The first line should not be wrapped but this one should because the link starts [after the max length](http://www.somelonglink.com/a/b/c/1/2/3).
 
 [Marvin.Henry], but after a few users adopted it for their various needs we wanted to migrate it to a more general [GitLab Group].
+
+Inline Code
+-----------
+
+Inline code is surrounded by `back-ticks`.  Long spans of code `should not be split into multiple lines`.
+Inline code can be delimited by either `one` or ``two`` back-ticks.
+
+When started with two back-ticks, a single back-tick will not end the code span so that code containing back-ticks does not need to be escaped.
+Long spans of code should not be split into multiple lines when ``enclosed ` within two back-ticks``.
+
+Preformatted Text
+-----------------
+
+    Preformatted paragraphs can either be indented by four spaces or fenced by adding ` ``` ` before the first line and after the last.
+
+```
+Preformatted paragraphs can either be indented by four spaces or fenced by adding ` ``` ` before the first line and after the last.
+
+Paragraphs within the ``` fences should be reflowed separately.
+```
+
+```javascript
+// Preformatted paragraphs can also have a language keyword to indicate the language to use for syntax highlighting.
+let a = 1;
+let b = 2;
+// TODO: Only wrap comments within comment blocks based on syntax highlighting.
+```


### PR DESCRIPTION
Hi, I've made a few enhancements to the ReflowMarkdown extension.

  - Add `reflowMarkdown.doubleSpaceBetweenSentences` setting to insert two spaces instead of one between sentences.
  - Don't split inline code spans onto separate lines.
  - Support fenced code blocks surrounded by three back-ticks (` ``` `)
  - Don't change the indentation level when reflowing blockquotes.
  - Within numbered and bulleted lists, keep the indentation before and the number of spaces after a list marker unchanged.

Please have a look at my PR, and let me know if you would like to accept it as is or if it needs any further changes.