### PR TITLE
Allow lines to be preferredLineLength characters long

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -65,7 +65,7 @@ export function reflow() {
             // if the current line length is already longer than the max length, push it to the new lines array
             // OR if our word does NOT start with a left square bracket (i.e. is not a .md hyperlink) AND
             // if adding it and a space would make the line longer than the max length, also push it to the new lines array
-            if (curLine.length >= curMaxLineLength || (word[0] != "[" && curLine.length + 1 + word.length >= curMaxLineLength)) {
+            if (curLine.length > curMaxLineLength || (word[0] != "[" && curLine.length + 1 + word.length > curMaxLineLength)) {
                 newLines.push(curLine.replace(/\s*$/, ''));  //remove trailing whitespace
                 curLine = sei.indents.otherLines;
             } 


### PR DESCRIPTION
instead of capping them at preferredLineLength - 1. This behavior should also match the description in the above comment: "if the current line length is already longer than the max length". Currently it is checking if it's longer _or_ equal.

I noticed that another VS Code reflow package has [the same bug](https://github.com/dontrolle/vscode-reflow-lines/issues/7) but since they don't seem be maintaining the project actively I'm submitting this fix here in hopes that it will get accepted so that I can start using this package. Note that I haven't tested this change.